### PR TITLE
Allow overflow on tables

### DIFF
--- a/views/assets/stylesheets/components/input.css
+++ b/views/assets/stylesheets/components/input.css
@@ -68,7 +68,7 @@
 	font-size: var(--size-md);
 	top: 16px;
 	height: 35px;
-	left: 8px;
+	left: 10px;
 	z-index: 500;
 	border-right: var(--default-border);
 	background-color: var(--white);

--- a/views/assets/stylesheets/components/table.css
+++ b/views/assets/stylesheets/components/table.css
@@ -1,5 +1,5 @@
 .tyk-table__wrapper {
-	overflow-y: hidden; /* fixes the overflow of a long table  */
+	overflow: visible;
 	width: 100%;
 	border: var(--default-border);
 }


### PR DESCRIPTION
Since we're not going to have so many columns we don't need this option.
As per Sandra, we won't have such long tables anyway so the quickest solution now is to use the default styling and rethink about it in the future if need be.