### PR TITLE
Solves issue #11

### DIFF
--- a/views/layout.tmpl
+++ b/views/layout.tmpl
@@ -58,11 +58,15 @@
             {{if $actions}}
               {{$actions}}
             {{end}}
-          {{if has_create_permission .Resource}}
-            <a class="tyk-button tyk-button--success tyk-button--md action-button" href="{{new_resource_path .Resource}}" data-url="{{new_resource_path .Resource}}">
-              Add
-            </a>
-          {{end}}
+            {{if .Resource}}
+              {{$NotSingleton := not .Resource.Config.Singleton}}
+              {{$HasCreatePermission := has_create_permission .Resource}}
+              {{if and $NotSingleton $HasCreatePermission}}
+                <a class="tyk-button tyk-button--success tyk-button--md action-button" href="{{new_resource_path .Resource}}" data-url="{{new_resource_path .Resource}}">
+                  Add
+                </a>
+              {{end}}
+            {{end}}
         </div>
         {{.Content}}
       </main>


### PR DESCRIPTION
The error happens because the original snipped was in the `index.tmpl` file and now it's in the `layout.tmpl` file. 

The `layout.tmpl` is the master layout so it can be used with a template that has no resource associated with it, then when this code is reached
```
          {{if has_create_permission .Resource}}
            <a class="tyk-button tyk-button--success tyk-button--md action-button" href="{{new_resource_path .Resource}}" data-url="{{new_resource_path .Resource}}">
              Add
            </a>
          {{end}}
```
a nil value is passed to `has_create_permission`. This function expects a valid `HasPermissioner` object with a `HasPermission` receiver function, so this is why the `invalid memory address or nil pointer dereference` error is thrown.

To solve this I just check in the template if we have a resource object before calling the snipped, also don't call this if the resource is a singleton which shouldn't have an `Add` button.

Signed-off-by: Patricio Diaz <padiazg@gmail.com>