### PR TITLE
Refactoring the collapsible feature

### DIFF
--- a/views/assets/javascripts/modules.js
+++ b/views/assets/javascripts/modules.js
@@ -1,0 +1,3 @@
+import { Collapsible } from './modules/collapsible.js';
+
+let settingsCollapsablePanels = Collapsible();

--- a/views/assets/javascripts/modules/collapsible.js
+++ b/views/assets/javascripts/modules/collapsible.js
@@ -1,21 +1,21 @@
 export function Collapsible (options) {
-	let clickableElement = [...document.getElementsByClassName(options?.headerSelector || 'collapsible-header')];
+	let clickableElement = [...document.getElementsByClassName(options?.clickableSelector || 'collapsible-header')];
 	let collapsibleContent = [...document.getElementsByClassName(options?.contentSelector || 'collapsible-content')]
 
 	clickableElement.forEach((item,index) => {
   	item.addEventListener('click', () => {
-  		let arrowIcon = clickableElement[index].children[0];
+  		let arrowIcon = clickableElement[index].children[0].classList[0] === 'tyk-icon' ? clickableElement[index].children[0] : null;
 			if(
 					collapsibleContent[index].style.display.length === 0 ||
 					collapsibleContent[index].style.display === 'none'
 				) {
 				collapsibleContent[index].style.display = 'block'
-				arrowIcon.classList.remove('tykon-arrowup');
-				arrowIcon.classList.add('tykon-arrowdown');
+				arrowIcon?.classList.remove('tykon-arrowup');
+				arrowIcon?.classList.add('tykon-arrowdown');
 			} else {
 				collapsibleContent[index].style.display = 'none'
-				arrowIcon.classList.remove('tykon-arrowdown');
-				arrowIcon.classList.add('tykon-arrowup');
+				arrowIcon?.classList.remove('tykon-arrowdown');
+				arrowIcon?.classList.add('tykon-arrowup');
 			}
   	});
 	});

--- a/views/assets/javascripts/modules/collapsible.js
+++ b/views/assets/javascripts/modules/collapsible.js
@@ -1,0 +1,23 @@
+export function Collapsible (options) {
+	let clickableElement = [...document.getElementsByClassName(options?.headerSelector || 'collapsible-header')];
+	let collapsibleContent = [...document.getElementsByClassName(options?.contentSelector || 'collapsible-content')]
+
+	clickableElement.forEach((item,index) => {
+  	item.addEventListener('click', () => {
+  		let arrowIcon = clickableElement[index].children[0];
+			if(
+					collapsibleContent[index].style.display.length === 0 ||
+					collapsibleContent[index].style.display === 'none'
+				) {
+				collapsibleContent[index].style.display = 'block'
+				arrowIcon.classList.remove('tykon-arrowup');
+				arrowIcon.classList.add('tykon-arrowdown');
+			} else {
+				collapsibleContent[index].style.display = 'none'
+				arrowIcon.classList.remove('tykon-arrowdown');
+				arrowIcon.classList.add('tykon-arrowup');
+			}
+  	});
+	});
+};
+

--- a/views/assets/javascripts/tyk.js
+++ b/views/assets/javascripts/tyk.js
@@ -1,18 +1,3 @@
-$(document).ready(function () {
-	let rotated = false;
-
-	$('.collapsible-header').click(function () {
-	  const $header = $(this);
-	  const $content = $header.next();
-	  const $arrowIcon = $header.find('.tyk-icon.tykon');
-	  const contentIsVisible = $content.css('display') === 'block' ? true : false;
-
-  	$arrowIcon.removeClass(contentIsVisible ? 'tykon-arrowdown' : 'tykon-arrowup').addClass(contentIsVisible ? 'tykon-arrowup' : 'tykon-arrowdown');
-	  $content.slideToggle(400, function () {});
-	  rotated = !rotated;
-	});
-});
-
 /* On form cancel */
 function onCancel() {
 	let paths = window.location.pathname.split('/').filter(path => path);
@@ -25,3 +10,4 @@ function onCancel() {
 		window.location.href = backURL;
 	}
 }
+

--- a/views/layout.tmpl
+++ b/views/layout.tmpl
@@ -74,6 +74,7 @@
     </script>
     {{javascript_tag "qor_admin_default"}}
     {{javascript_tag "tyk"}}
+    <script type="module" src="admin/assets/javascripts/modules.js"></script>
     {{load_admin_javascripts}}
     {{load_theme_javascripts}}
   </body>


### PR DESCRIPTION
Addressed @lghiur comments from https://github.com/TykTechnologies/raava-admin/pull/8

Addresses https://tyktech.atlassian.net/browse/TT-2491 as well as a bit of file structuring

Now it is treated as a module and made it more flexible e.g

If we just initialise it with 
`
let myCollapsible = Collapsible();` then the module will use the "default" values to identify the clickable element (in our case the header) and the content that needs to be hidden/shown.

In case we want to use it further, we can pass some options but they have to have a specific key e.g 

```
let settingsCollapsablePanels = Collapsible({
 clickableSelector: 'clickable-element',
 contentSelector: 'collapsible-content'
});
```

Or even use both cases in the same page, if needed