### PR TITLE
[TT-3302] remove whitespace from textarea content

### DIFF
--- a/views/metas/form/text.tmpl
+++ b/views/metas/form/text.tmpl
@@ -6,9 +6,7 @@
     class="tyk-form-control qor-js-autoheight"
     id="{{.InputId}}"
     name="{{.InputName}}"
-    rows="1"
+    rows="2"
     {{if (not (has_change_permission .Meta)) }}disabled{{end}}
-    >
-    {{.Value}}
-  </textarea>
+    >{{ .Value }}</textarea>
 </div>


### PR DESCRIPTION
removing the literal whitespace of the HTML content in the template file

Signed-off-by: cmelgarejo <cmelgarejo.dev@gmail.com>

## Screenshots

Take a look at the selection of text in the *textarea* block

### Before

![image](https://user-images.githubusercontent.com/2163649/132357373-b6c195b6-cf44-45c6-babd-17f89a546b62.png)


### After

![image](https://user-images.githubusercontent.com/2163649/132357406-79edf741-339f-4ad1-9953-3a0b80186220.png)
