### PR TITLE
[TT-3180] TykPro provider metadata type

### DIFF
--- a/views/metas/form/client-config-tykpro.tmpl
+++ b/views/metas/form/client-config-tykpro.tmpl
@@ -1,0 +1,67 @@
+{{$current_values := raw_value_of .ResourceValue .Meta }}
+
+{{if $current_values}}
+<div class="tyk-form-group tyk-form-group--default tyk-form-group--rounded-corners">
+  <label for="{{.InputId}}-URL">URL:</label>
+  <div class="qor-field__show">{{$current_values.URL}}</div>
+  <div class="tyk-form-control__wrapper">
+    <input
+     autocomplete="off"
+     class="tyk-form-control"
+     name="{{.InputName}}"
+     type="text"
+     id="{{.InputId}}-URL"
+     value="{{$current_values.URL}}"
+    {{if (not (has_change_permission .Meta)) }}disabled{{end}}
+    />
+  </div>
+</div>
+
+<div class="tyk-form-group tyk-form-group--default tyk-form-group--rounded-corners">
+  <label for="{{.InputId}}-Secret">Secret:</label>
+  <div class="qor-field__show">{{$current_values.Secret}}</div>
+  <div class="tyk-form-control__wrapper">
+    <input
+     autocomplete="off"
+     class="tyk-form-control"
+     name="{{.InputName}}"
+     type="text"
+     id="{{.InputId}}-Secret"
+     value="{{$current_values.Secret}}"
+    {{if (not (has_change_permission .Meta)) }}disabled{{end}}
+    />
+  </div>
+</div>
+
+<div class="tyk-form-group tyk-form-group--default tyk-form-group--rounded-corners">
+  <label for="{{.InputId}}-OrgID">Organisation ID:</label>
+  <div class="qor-field__show">{{$current_values.OrgID}}</div>
+  <div class="tyk-form-control__wrapper">
+    <input
+     autocomplete="off"
+     class="tyk-form-control"
+     name="{{.InputName}}"
+     type="text"
+     id="{{.InputId}}-OrgID"
+     value="{{$current_values.OrgID}}"
+    {{if (not (has_change_permission .Meta)) }}disabled{{end}}
+    />
+  </div>
+</div>
+
+<div class="tyk-form-group tyk-form-group--default tyk-form-group--rounded-corners">
+  <label for="{{.InputId}}-PoliciesTagsFlat">Policies Tags:</label>
+  <div class="qor-field__show">{{$current_values.PoliciesTagsFlat}}</div>
+  <div class="tyk-form-control__wrapper">
+    <input
+     autocomplete="off"
+     class="tyk-form-control"
+     name="{{.InputName}}"
+     type="text"
+     id="{{.InputId}}-PoliciesTagsFlat"
+     value="{{$current_values.PoliciesTagsFlat}}"
+    {{if (not (has_change_permission .Meta)) }}disabled{{end}}
+    />
+  </div>
+</div>
+{{end}}


### PR DESCRIPTION
As a dashboard developer, I need to edit the TykPro provider metadata in a form like way, not just a plain string JSON.

The metadata is stored in plain text JSON format in the `meta_data` field on the `provider_configs` table. Currently, the user must create that JSON string manually and write it down in the field.
![Captura de pantalla de 2021-09-30 09-04-38](https://user-images.githubusercontent.com/15754252/135460700-cb14efd8-89d3-4824-b3f1-b8e2711156fd.png)

With this new type, the user can edit the four fields from the metadata in a more user-friendly form
![Captura de pantalla de 2021-09-30 09-03-43](https://user-images.githubusercontent.com/15754252/135460833-46010058-4d1c-494a-ad31-037c8af67c7e.png)
